### PR TITLE
add Calendly link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 <img src="https://raw.githubusercontent.com/jrsec/jrsec/main/assets/gh-header-image-blue.png" alt="banner that says Jorge Reyes - security manager, devsecops engineer, and adjunct professor alongside a cartoon illustration">
 
-As a lifelong learner, I'm passionate about sharing knowledge.
-I contribute to open-source projects and enjoy teaching others about security and automation.
-Check out my projects and articles at my [portfolio website](https://jrsec.github.io)!
+As a **Security Manager** and **DevSecOps Engineer**, I'm driven by continuous learning and sharing expertise.  I contribute to 🛠️ open-source security projects and enjoy teaching as an **Adjunct Professor**.
+
+Need help with **security architecture** or **career growth**?  I offer private consultation and career strategy sessions.  [🗓️ Schedule a quick chat](https://calendly.com/jr-sec) on Calendly!
+
+You can find my latest work and articles at my [💻 portfolio website](https://jrsec.github.io).
 
 ### Languages and Tools
 ![AWS](https://img.shields.io/badge/-AWS-%23232F3E?style=round-square&logo=icloud&logoColor=ffffff)


### PR DESCRIPTION
### What does this PR do?
This PR significantly enhances the GitHub Profile `README` (`README.md`) to clearly communicate my professional roles and offer direct access to consulting services.
Specifically, it:
- Updates the bio to reflect my roles.
- Adds a direct, high-visibility Calendly link (`https://calendly.com/jr-sec`) as a Call-to-Action (CTA) for private consultation and career strategy sessions.
- Introduces relevant emojis (🗓️, 🛠️, 💻) to enhance the visual appeal and scannability of the key links.

### Where should the reviewer start?
Review the changes in `README.md` starting at line 4 to verify the integration of the new professional bio and the Calendly CTA link.

### Scope of Impact
Scope: **Minor**.
This change is limited entirely to the GitHub Profile `README`. It has no impact on any other repository, branch, or live site functionality. The changes are purely cosmetic and informational for visitors viewing the profile page.

### Testing Plan
1. View the main GitHub profile page (`https://github.com/jrsec`).
2. Verify the updated professional bio text is displayed correctly.
3. Click the _"🗓️ Schedule a quick chat"_ link to ensure it successfully opens the Calendly scheduling page.
4. Confirm the emojis (🛠️ and 💻) render correctly next to the corresponding text.

### Context
This update aligns the GitHub profile messaging with the strategic consulting and career mentorship focus being implemented across my professional web presence (related to recent changes in my GitHub Pages site). This ensures a consistent and high-value user experience across platforms.