### PR TITLE
Update bio to emphasize specialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="https://raw.githubusercontent.com/jrsec/jrsec/main/assets/gh-header-image-blue.png" alt="banner that says Jorge Reyes - security manager, devsecops engineer, and adjunct professor alongside a cartoon illustration">
 
-As a **Security Manager** and **DevSecOps Engineer**, I'm driven by continuous learning and sharing expertise.  I contribute to 🛠️ open-source security projects and enjoy teaching as an **Adjunct Professor**.
+As a **Security Manager** and **DevSecOps Engineer**, I've specialized in **security architecture** and **career growth**.  I'm driven by continuous learning and sharing expertise.  I contribute to 🛠️ open-source security projects and enjoy teaching as an **Adjunct Professor**.
 
-Need help with **security architecture** or **career growth**?  I offer private consultation and career strategy sessions.  [🗓️ Schedule a quick chat](https://calendly.com/jr-sec) on Calendly!
+[🗓️ Schedule a quick chat](https://calendly.com/jr-sec) on Calendly!
 
 You can find my latest work and articles at my [💻 portfolio website](https://jrsec.github.io).
 


### PR DESCRIPTION
Refines the personal introduction to highlight specialized experience in security architecture and career growth directly in the bio.  Adjusts the consultation call-to-action to be more passive and cleaner by placing the scheduling link on its own line.

Changes:
- Integrated specialization details into the main bio paragraph.
- Replaced the direct "Need help?" question with a standalone Calendly link for a streamlined look.